### PR TITLE
Add Claude Code handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pydantic-settings>=2.9.1",
     "redis>=6.2.0",
     "sqlalchemy>=2.0.41",
+    "claude-code-sdk>=0.0.14",
 ]
 
 [project.optional-dependencies]

--- a/src/bot/handlers/base.py
+++ b/src/bot/handlers/base.py
@@ -1,11 +1,89 @@
-from aiogram import Router, types
+import asyncio
+from pathlib import Path
+from subprocess import PIPE
+
+from aiogram import F, Router, types
 from aiogram.filters import CommandStart
+from aiogram.fsm.context import FSMContext
+from aiogram.utils.chat_action import ChatActionSender
+
+from claude_code_sdk import AssistantMessage, TextBlock, query, ClaudeCodeOptions
 
 from database.models import User
+from bot.states import AddProjectStates
 
 router = Router()
 
 
 @router.message(CommandStart())
 async def start_message(message: types.Message, user: User) -> None:
-    await message.answer(text=f"Hello, {user.fullname}.")
+    keyboard = types.ReplyKeyboardMarkup(
+        resize_keyboard=True,
+        keyboard=[[types.KeyboardButton(text="Projects"), types.KeyboardButton(text="Add project")]],
+    )
+    await message.answer(text=f"Hello, {user.fullname}.", reply_markup=keyboard)
+
+
+@router.message(F.text == "Add project")
+async def add_project_prompt(message: types.Message, state: FSMContext) -> None:
+    await state.set_state(AddProjectStates.waiting_for_url)
+    await message.answer("Send me the project repository URL")
+
+
+@router.message(AddProjectStates.waiting_for_url)
+async def add_project_clone(message: types.Message, state: FSMContext) -> None:
+    if not message.text:
+        return
+    repo_url = message.text.strip()
+    projects_dir = Path("projects")
+    projects_dir.mkdir(exist_ok=True)
+
+    async with ChatActionSender.typing(chat_id=message.chat.id, bot=message.bot):
+        process = await asyncio.create_subprocess_exec(
+            "git",
+            "clone",
+            repo_url,
+            cwd=projects_dir,
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+        stdout, stderr = await process.communicate()
+
+    if process.returncode == 0:
+        text = "Project cloned successfully"
+    else:
+        text = f"Failed to clone project (code {process.returncode}).\n{stderr.decode()}"
+    await state.clear()
+    await message.answer(text)
+
+
+@router.message(F.text == "Projects")
+async def list_projects(message: types.Message) -> None:
+    projects_dir = Path("projects")
+    if not projects_dir.exists():
+        await message.answer("No projects added yet")
+        return
+    projects = [p.name for p in projects_dir.iterdir() if p.is_dir()]
+    if not projects:
+        await message.answer("No projects added yet")
+        return
+    await message.answer("Projects:\n" + "\n".join(projects))
+
+
+@router.message()
+async def claude_code_handler(message: types.Message) -> None:
+    if not message.text:
+        return
+
+    options = ClaudeCodeOptions(allowed_tools=["Read", "Write"])
+    result_chunks: list[str] = []
+
+    async with ChatActionSender.typing(chat_id=message.chat.id, bot=message.bot):
+        async for msg in query(prompt=message.text, options=options):
+            if isinstance(msg, AssistantMessage):
+                for block in msg.content:
+                    if isinstance(block, TextBlock):
+                        result_chunks.append(block.text)
+
+    if result_chunks:
+        await message.answer("\n".join(result_chunks))

--- a/src/bot/states.py
+++ b/src/bot/states.py
@@ -1,0 +1,8 @@
+from aiogram.fsm.state import State, StatesGroup
+
+
+class AddProjectStates(StatesGroup):
+    """States for the add project flow."""
+
+    waiting_for_url = State()
+


### PR DESCRIPTION
## Summary
- add dependency on `claude-code-sdk`
- implement a handler that forwards text messages to Claude Code and replies with the result
- show a typing status while waiting for Claude Code to respond
- add main menu with project management options
- use FSM to handle cloning a project repository

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687dbdd7d1008333938e096aa82fb9bd